### PR TITLE
Change the include guard macro

### DIFF
--- a/boopes.h
+++ b/boopes.h
@@ -1,5 +1,5 @@
-#ifndef D46FF7A0_740D_4319_B785_9B6F99A23FD5
-#define D46FF7A0_740D_4319_B785_9B6F99A23FD5
+#ifndef _BOOPES_H_
+#define _BOOPES_H_
 
 #include <stdlib.h>
 
@@ -13,4 +13,4 @@
 #define delete(object) free(object)
 
 
-#endif /* D46FF7A0_740D_4319_B785_9B6F99A23FD5 */
+#endif /* _BOOPES_H_ */


### PR DESCRIPTION
The include guard macro should not be nonsense. It should signify the header file. I chose `_BOOPES_H_`, but we could pick something else if you wish.