### PR TITLE
A more natural way of class creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ you need a c preprocessor that supports ##__VA_ARGS__ because boopes uses this. 
 ```c
 #include "boopes.h"
 //the class YourClass derives from object
-class(YourClass) inherits_from(object)
-//classes can have variables.
-int a;
-//a method prototype
-method_proto(YourClass, MethodReturnType, MethodName);
-//the end of the class definition
-class_end(YourClass)
+class(YourClass) { 
+    inherits_from(object)
+    //classes can have variables.
+    int a;
+    //a method prototype
+    method_proto(YourClass, MethodReturnType, MethodName);
+}; // the end of the class definition
 ```
 constructors need to be crated manually. for example, a constructor for the class above could be
 ```c

--- a/boopes.h
+++ b/boopes.h
@@ -3,8 +3,7 @@
 
 #include <stdlib.h>
 
-#define class(ClassName) typedef struct ClassName {
-#define class_end(ClassName) } ClassName ;
+#define class(ClassName) typedef struct ClassName ClassName; struct ClassName
 #define method_proto(ClassName, RetVal, name, ...) RetVal (*name) (struct ClassName*, ##__VA_ARGS__)
 #define method_def(ClassName, RetVal, MethodName, ...) RetVal MethodName (ClassName* this, ##__VA_ARGS__)
 #define inherits_from(ClassName) ClassName super;


### PR DESCRIPTION
The following pull request removes the need to use class_end for classes.

Before this PR, this needed to be done to create a class:
```c
class(Rectangle)
    int length;
    int width;
class_end(Rectangle)
Rectangle rect;
```
It has no curly braces, and needs the class name twice.

However, this pull request makes class creation much more natural:
```c
class(Rectangle) {
    int x;
    int y;
};
Rectangle rect;
```
which looks almost like C++.

The way I did this was by changing the `class()` macro to `typedef` the class first, then declare a struct. The `};` which replaces `class_end()` is just the end of that struct definition.

My only concern with this PR is that inheritance looks a bit worse:
```c
class(Tower) { inherits_from(Building)
    // implementation
};
```
The opening curly brace has to come before the `inherits_from`, which is the problem, since other OOP languages put the inheritance outside of the curly braces. I wonder if this could be fixed in the future.